### PR TITLE
Add HAVE_DIRENT_DTYPE support, so entry type is exposed in dirent.

### DIFF
--- a/src/scandir.c
+++ b/src/scandir.c
@@ -44,6 +44,9 @@ int ag_scandir(const char *dirname,
         d = (struct dirent *)malloc(sizeof(struct dirent) + s_len);
         char *s = (char*)d + sizeof(struct dirent);
         d->d_name = s;
+#ifdef HAVE_DIRENT_DTYPE
+        d->d_type = entry->d_type;
+#endif
         memcpy(s, entry->d_name, s_len);
 #else
 

--- a/wincompat/dirent.c
+++ b/wincompat/dirent.c
@@ -15,6 +15,7 @@
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <io.h>
 
 #ifdef __cplusplus
 extern "C"
@@ -106,6 +107,9 @@ struct dirent *readdir(DIR *dir)
         {
             result         = &dir->result;
             result->d_name = dir->info.name;
+#ifdef HAVE_DIRENT_DTYPE
+            result->d_type = dir->info.attrib & _A_SUBDIR ? DT_DIR : DT_REG;
+#endif
         }
     }
     else

--- a/wincompat/dirent.h
+++ b/wincompat/dirent.h
@@ -18,9 +18,31 @@ extern "C"
 
 typedef struct DIR DIR;
 
+#define HAVE_DIRENT_DTYPE
+
+#ifdef HAVE_DIRENT_DTYPE
+enum DirType
+{
+    DT_UNKNOWN = 0,
+    DT_FIFO = 1,
+    DT_CHR = 2,
+    DT_DIR = 4,
+    DT_BLK = 6,
+    DT_REG = 8,
+    DT_LNK = 10,
+    DT_SOCK = 12,
+    DT_WHT = 14,
+};
+#endif
+
+// If you add additional fields to this struct, you'll need to update
+// ag_scandir.
 struct dirent
 {
     char *d_name;
+#ifdef HAVE_DIRENT_DTYPE
+    unsigned char d_type;
+#endif
 };
 
 DIR           *opendir(const char *);


### PR DESCRIPTION
Save on stat calls.

On my laptop, without `HAVE_DIRENT_DTYPE`, running in a Parallels VM on Windows 8.1, after a few runs to warm things up:

```
> C:\tom\github\the_silver_searcher\rel\ag.exe --stats 001309 c:\temp\agtest
c:\temp\agtest\000\019\009.txt
1:001309
1 matches
10000 files searched
60000 bytes searched
1.421864 seconds
```

And then with `HAVE_DIRENT_DTYPE`:

```
> C:\tom\github\the_silver_searcher\rel\ag.exe --stats 001309 c:\temp\agtest
c:\temp\agtest\000\019\009.txt
1:001309
1 matches
10000 files searched
60000 bytes searched
0.436341 seconds
```

When running native, the speedup is proportionally the same.

The test data I used was generated by https://raw.githubusercontent.com/tom-seddon/the_silver_searcher/289332970e0455bcbb544dbbaf1bdb8cb8fcde21/testskjk/lots_of_folders/make_lots_of_folders.py.

I couldn't get the tests to work on my PC:

```
c:\tom\github\the_silver_searcher>scripts\runtests.bat
run_cmd_throw: 'c:\tom\github\the_silver_searcher\rel\ag.exe --version'
ag version 0.29.1

Features:
  -jit -lzma -zlib

testskjk\test00.txt
2 tests in testskjk\test00.txt
Running test 1 (no files at all), 1 subtests
run_cmd: 'c:\tom\github\the_silver_searcher\rel\ag.exe --ackmate foo'
Error 1. Stdout:
''
 Stderr:
''
```

Anyway, even if you don't want this exact pull request, this change is well worth doing as it's a lot quicker on Windows to get details from the `FindFirstFile` call than it is to do a separate `stat` afterwards.

--Tom
