### PR TITLE
On Win32 put the console into binary mode to correctly handle '\r\n' …

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -20,6 +20,12 @@
 #include "search.h"
 #include "util.h"
 
+#ifdef _WIN32
+void restore_stdout() {
+    setmode(fileno(stdout), O_TEXT);
+}
+#endif
+
 typedef struct {
     pthread_t thread;
     int id;
@@ -47,7 +53,13 @@ int main(int argc, char **argv) {
     work_queue_tail = NULL;
     memset(&stats, 0, sizeof(stats));
     root_ignores = init_ignore(NULL, "", 0);
+
+#ifdef _WIN32
+    setmode(fileno(stdout), O_BINARY);
+    atexit(restore_stdout);
+#endif
     out_fd = stdout;
+
 #ifdef USE_PCRE_JIT
     int has_jit = 0;
     pcre_config(PCRE_CONFIG_JIT, &has_jit);


### PR DESCRIPTION
The Windows console does newline conversion so '\n' is output as '\r\n' which lead to doubled ^M characters in the output.

This is tested with "normal" console output as well as --vimgrep output which uses different functionality to write the lines. In Vim especially, the extra ^M characters in the output were annoying.