### PR TITLE
~/.agignore and avoiding extraneous ^M

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -20,6 +20,14 @@
 #include "search.h"
 #include "util.h"
 
+#ifdef _WIN32
+static int old_mode = _O_TEXT;
+void restore_stdout() {
+    fflush(stdout);
+    _setmode(fileno(stdout), _O_TEXT);
+}
+#endif
+
 typedef struct {
     pthread_t thread;
     int id;
@@ -47,7 +55,13 @@ int main(int argc, char **argv) {
     work_queue_tail = NULL;
     memset(&stats, 0, sizeof(stats));
     root_ignores = init_ignore(NULL, "", 0);
+
+#ifdef _WIN32
+    old_mode = _setmode(fileno(stdout), _O_BINARY);
+    atexit(restore_stdout);
+#endif
     out_fd = stdout;
+
 #ifdef USE_PCRE_JIT
     int has_jit = 0;
     pcre_config(PCRE_CONFIG_JIT, &has_jit);

--- a/src/options.c
+++ b/src/options.c
@@ -24,6 +24,12 @@ const char *color_path = "\033[1;32m";        /* bold green */
 #define BUFFER_SIZE 4096
 
 #ifdef _MSC_VER
+#define HOME_VAR    "USERPROFILE"
+#else
+#define HOME_VAR    "HOME"
+#endif
+
+#ifdef _MSC_VER
 /* Unlike popen(), it doesn't pollutes stderr if the executable doesn't exist.
    This might be common on Windows (no git installed)
 */
@@ -279,7 +285,7 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
     int list_file_types = 0;
     int opt_index = 0;
     char *num_end;
-    const char *home_dir = getenv("HOME");
+    const char *home_dir = getenv(HOME_VAR);
     char *ignore_file_path = NULL;
     int accepts_query = 1;
     int needs_query = 1;


### PR DESCRIPTION
I'm not sure how to split these into two separate PRs. Sorry about that.

1. Win32 console stdout is put into binary mode so that what is essentially echoing the `\r\n` from input files to the console doesn't double the `^M` characters. In text mode, `\n` is expanded to `^M^J` already but we don't want that because `\r` is `^M`. stdout is restored to text mode at application shutdown. I don't know if it's necessary to reset it or not but I figured it was safest to do so.
1. I always want to ignore my `tags` file so I fought with `~/.agignore` for a while before figuring out it simply didn't work in Windows. Win32 builds use `getenv("USERPROFILE")` instead of `getenv("HOME")`.